### PR TITLE
Fix periodicity bug

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,12 +24,13 @@ Basic rules for branch names:
     7. General branches: `gen/<branch-name>`
 
 Current tasks:
-1. Fix periodicity bug.
-2. Consider using APScheduler instead of Celery.
-3. Allow modifying event parameters without overwriting other settings.
-4. Allow exporting chat config (it's already being saved in database so should be easy).
-5. Add caching to service layer.
-6. Refactor service, repository and handlers layers.
-7. General refactoring.
-8. Rename app folder to bot.
-9. Fix skipping logic.
+* Consider using APScheduler instead of Celery.
+* Allow modifying event parameters without overwriting other settings.
+* Allow exporting chat config (it's already being saved in database so should be easy).
+* Add caching to service layer.
+* Refactor service layer.
+* Refactor repository layer.
+* Refactor handlers layer.
+* General refactoring.
+* Rename app folder to bot.
+* Fix skipping logic.

--- a/Makefile
+++ b/Makefile
@@ -25,12 +25,14 @@ rebuild: ## Stop all docker containers, rebuild the pqbot image, and start all c
 	make up
 
 .PHONY: logs
-logs: ## Show logs for pqbot:latest container
-	@docker compose -f deployments/local/compose.yaml -p ${APP_NAME} logs ${APP_NAME} -f
+logs: ## Show logs for specified container
+	@read -p "Enter a container name: " container; \
+	docker compose -f deployments/local/compose.yaml -p ${APP_NAME} logs $$container -f
 
 .PHONY: sh
-sh: ## Open shell for pqbot:latest container
-	@docker compose -f deployments/local/compose.yaml -p ${APP_NAME} exec ${APP_NAME} sh
+sh: ## Open shell for specified container
+	@read -p "Enter a container name: " container; \
+	docker compose -f deployments/local/compose.yaml -p ${APP_NAME} exec $$container sh
 
 .PHONY: migrate
 migrate: ## Run all migrations

--- a/app/tasks/tasks.py
+++ b/app/tasks/tasks.py
@@ -71,4 +71,5 @@ def send_event_notification_message_task(event_id: str):
                 eta=event.next_date - service.evaluate_event_offset(event=event),
             )
 
-    asyncio.run(task())
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(task())

--- a/deployments/local/compose.yaml
+++ b/deployments/local/compose.yaml
@@ -3,8 +3,12 @@ services:
     image: pqbot:latest
     env_file:
       - env_files/dev.env
+    depends_on:
+      - postgres
+      - rabbitmq
     volumes:
       - ../../:/app
+
   postgres:
     image: postgres:17-alpine
     environment:
@@ -14,6 +18,7 @@ services:
       - postgres:/var/lib/postgresql/data
     ports:
       - 5432:5432
+
   pgadmin:
     image: dpage/pgadmin4
     environment:
@@ -26,8 +31,10 @@ services:
       - pgadmin:/var/lib/pgadmin
     ports:
       - 5050:5050
+
   rabbitmq:
     image: rabbitmq:4-alpine
+    hostname: rabbitmq
     environment:
       - RABBITMQ_DEFAULT_USER=rabbitmq
       - RABBITMQ_DEFAULT_PASS=rabbitmq
@@ -39,6 +46,7 @@ services:
       - rabbitmq:/var/lib/rabbitmq/
     ports:
       - 5672:5672
+
   celery:
     <<: *pqbot
     command: celery -A app.tasks.tasks worker -l info


### PR DESCRIPTION
We had a bug when running multiple celery `send_event_notification_message_task` tasks that would throw `attached to a different loop`. The error was caused by `asyncio.run(...)` call that would create a new event loop for each task execution which led to celery worker have multiple event loops resulting in `attached to a different loop` error.
Fixed it using `asyncio.get_event_loop()` call and then called `run_until_complete` on it therefore utilizing only one event loop.

Also fixed rabbitmq not having persistent queue resulting in event notification messages not being sent after broker container restart. Had to specify hostname for rabbitmq container.
docker-library/rabbitmq#106 