### PR TITLE
Fix celery tasks with far ETA

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,7 @@ repos:
     rev: v5.0.0
     hooks:
       - id: trailing-whitespace
+        exclude: README.md
       - id: end-of-file-fixer
 
   - repo: https://github.com/astral-sh/ruff-pre-commit

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Bot manages creation of queues / attendance lists for periodic events.
 ![Notification message example](assets/images/notification_message_example.jpg "Notification message example")
 
 ## Prerequisites:
-You will need `docker` to be installed on your system.
+You will need `docker` to be installed on your system.  
 See: https://docs.docker.com/engine/install/
 
 ## Configuration:
@@ -27,12 +27,12 @@ Example of a configuration file:
         {
             "name": "Mandatory Dota 2 session",
             "initial_date": "03-10-2024 16:00:00 +0200",
-            "offset": {
-                "days": "2 + 3 * (t % 2)"
-            }
             "periodicity": {
                 "days": "2 + 3 * (n % 2)"
             },
+            "offset": {
+                "days": "2 + 3 * (t % 2)"
+            }
         }
     ]
 }
@@ -58,7 +58,7 @@ Each `events` object has fields:
 - `minutes`: Optional field. Formula to calculate minutes.
 - `seconds`: Optional field. Formula to calculate seconds.
 
-## Periodicity
+## Periodicity and Offset
 You can create periodic event that happens every day:
 ```
 {
@@ -82,14 +82,14 @@ Every week and one day (if this week the event has occurred on Friday, next week
 ```
 And so on.
 
-**Values in periodicity fields are not just numbers. They are formulas.**
+**Values in periodicity and offset fields are not just numbers. They are formulas.**
 You can use variables `t` and `n` in them to create more complex rules.
 
-The `t` variable stands for the number of times an event has already occurred.
+The `t` variable stands for the number of times an event has already occurred.  
 The `n` variable stands for the ordinal number of an event that the next date is being
-calculated for, so `n` always equals `t + 1`.
+calculated for, so `n` always equals `t + 1`.  
 The `n` variable introduced solely for the purpose of writing clean formulas without the
-need of `t + 1` to immitate the value of `n` variable.
+need of `t + 1` to immitate the value of `n` variable.  
 You can specify `times_occurred` value when creating an event, then the `t` variable
 for the next event calculation will be equal to `times_occurred` and `n` will be
 equal to `times_occurred + 1`.
@@ -98,25 +98,35 @@ equal to `times_occurred + 1`.
 {
     "name": "Biweekly event",
     "initial_date": "01-11-2024 12:30:00 +0200",
+    "periodicity": {
+        "days": "2 + 3 * (n % 2)"
+    },
     "offset": {
         "days": "2 + 3 * (t % 2)",
         "minutes": "10"
-    }
-    "periodicity": {
-        "days": "2 + 3 * (n % 2)"
-    }
-    "times_occurred": 2,
+    },
+    "times_occurred": 2
 }
 ```
 This way we can create an event that happens weekly on Thursdays and Fridays,
 with notification message for an event wiil be sent 10 minutes before the previous event.
 (E.g. notification message for Friday's event will be sent 10 minutes before Thursday's event).
-**If periodicity value ends up being irrational it will be rounded using Python's standard `round`
-function. Minimum allowed periodicity is one (1) minute.**
+
+If periodicity value ends up being irrational it will be rounded using Python's standard `round` function.
+
+**Minimum allowed periodicity is one (1) minute, maximum allowed periodicity is two (2) years.**  
+**Maximum allowed offset is two (2) years.**
+
+If periodicity is outside the allowed range, the event will **not** occur.  
+If offset is outside the allowed range, **no** offset will be used.  
+**It's user's responsibility to ensure that periodicity value within the allowed range.**  
+
+Also, the notification message for the `n + 1`th event should not occur before
+the notification message for `n`th event. Otherwise the bot will not work as expected.
 
 ## Hosting
-Fastest way to host the bot is to host it locally. Even though it's not the best way but it's the easiest.
-All you need is `docker` installed on your system.
+Fastest way to host the bot is to host it locally. Even though it's not the best way but it's the easiest.  
+All you need is `docker` installed on your system.  
 See: https://docs.docker.com/engine/install/
 
 Quickstart:

--- a/app/config.py
+++ b/app/config.py
@@ -52,8 +52,14 @@ class Config(BaseSettings):
     model_config = SettingsConfigDict(env_nested_delimiter="__")
 
     token: str = Field(default=...)
+
     date_format: str = "%d-%m-%Y %H:%M:%S %z"
+
     min_periodicity: RelativeDelta = RelativeDelta(minutes=1)
+    max_periodicity: RelativeDelta = RelativeDelta(years=2)
+
+    min_offset: RelativeDelta = RelativeDelta()
+    max_offset: RelativeDelta = RelativeDelta(years=2)
 
     postgres: PostgresConfig = Field(default=...)
     database_url: typing.Annotated[str, AfterValidator(build_database_url)] = ""

--- a/app/service/service_test.py
+++ b/app/service/service_test.py
@@ -195,7 +195,7 @@ def test_service_update_event_next_date(service: Service):
                 initial_date=now - RelativeDelta(minutes=10),
                 next_date=now - RelativeDelta(minutes=10),
                 times_occurred=0,
-                offset=schema.Period(minutes="4"),
+                offset=schema.Period(minutes="4", seconds="30"),
                 periodicity=schema.Period(minutes="15"),
             ),
             schema.Event(
@@ -205,7 +205,7 @@ def test_service_update_event_next_date(service: Service):
                 initial_date=now - RelativeDelta(minutes=10),
                 next_date=now + RelativeDelta(minutes=20),
                 times_occurred=2,
-                offset=schema.Period(minutes="4"),
+                offset=schema.Period(minutes="4", seconds="30"),
                 periodicity=schema.Period(minutes="15"),
             ),
         ),
@@ -248,10 +248,10 @@ def test_service_evaluate_event_periodicity(service: Service):
                 name="",
                 initial_date=now,
                 next_date=now,
-                periodicity=schema.Period(seconds="10"),
+                periodicity=None,
                 times_occurred=1,
             ),
-            config.min_periodicity,
+            None,
         ),
         (
             schema.Event(
@@ -259,10 +259,21 @@ def test_service_evaluate_event_periodicity(service: Service):
                 name="",
                 initial_date=now,
                 next_date=now,
-                periodicity=None,
+                periodicity=schema.Period(years="3"),
                 times_occurred=1,
             ),
-            config.min_periodicity,
+            None,
+        ),
+        (
+            schema.Event(
+                chat_id=0,
+                name="",
+                initial_date=now,
+                next_date=now,
+                periodicity=schema.Period(seconds="10"),
+                times_occurred=1,
+            ),
+            None,
         ),
     ]
 
@@ -304,6 +315,28 @@ def test_service_evaluate_event_offset(service: Service):
                 initial_date=now,
                 next_date=now,
                 offset=None,
+                times_occurred=1,
+            ),
+            RelativeDelta(),
+        ),
+        (
+            schema.Event(
+                chat_id=0,
+                name="",
+                initial_date=now,
+                next_date=now,
+                offset=schema.Period(minutes="-1"),
+                times_occurred=1,
+            ),
+            RelativeDelta(),
+        ),
+        (
+            schema.Event(
+                chat_id=0,
+                name="",
+                initial_date=now,
+                next_date=now,
+                offset=schema.Period(years="3"),
                 times_occurred=1,
             ),
             RelativeDelta(),

--- a/deployments/local/compose.yaml
+++ b/deployments/local/compose.yaml
@@ -38,6 +38,7 @@ services:
     environment:
       - RABBITMQ_DEFAULT_USER=rabbitmq
       - RABBITMQ_DEFAULT_PASS=rabbitmq
+      - RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS=-rabbit consumer_timeout 126489600000
     healthcheck:
       test: rabbitmq-diagnostics -q ping
       interval: 30s


### PR DESCRIPTION
Celery tasks with countdown over 15 minutes would throw `PRECONDITION FAILED` error due to RabbitMQ's consumer timeout. Changed consumer timeout to be a little over 4 years.
Due to this, enforced requirements for periodicity and offset to be maximum of 2 years. (So they sum up to at max 4 years).

https://docs.celeryq.dev/en/stable/userguide/calling.html#eta-and-countdown
